### PR TITLE
Expose instance object to id mapper to python scripts

### DIFF
--- a/org.osate.contract/src/org/osate/contract/execution/InstanceObjectIDMapper.java
+++ b/org.osate.contract/src/org/osate/contract/execution/InstanceObjectIDMapper.java
@@ -32,11 +32,24 @@ import org.osate.aadl2.instance.SystemInstance;
 
 public class InstanceObjectIDMapper {
 
+	private SystemInstance root;
+
 	private HashMap<InstanceObject, Integer> io2id = new HashMap<>();
 
 	private HashMap<Integer, InstanceObject> id2io = new HashMap<>();
 
-	public InstanceObjectIDMapper(SystemInstance root) {
+	private static InstanceObjectIDMapper mapper = null;
+
+	public static InstanceObjectIDMapper getMapper(SystemInstance root) {
+		if (mapper != null && mapper.root == root) {
+			return mapper;
+		}
+		mapper = new InstanceObjectIDMapper(root);
+		return mapper;
+	}
+
+	private InstanceObjectIDMapper(SystemInstance root) {
+		this.root = root;
 		int id = 0;
 		// aadl resource may contain additional root objects for instantiated referenced classifiers
 		var iter = root.eResource().getAllContents();

--- a/org.osate.contract/src/org/osate/contract/execution/PythonBuilder.java
+++ b/org.osate.contract/src/org/osate/contract/execution/PythonBuilder.java
@@ -67,6 +67,7 @@ public class PythonBuilder {
 		this.context = context;
 		python = PythonHelper.get();
 		java = JavaHelper.get();
+		variables.put("to_java", python.getInstanceObjectMapper());
 	}
 
 	PythonBuilder addZ3Import() {

--- a/org.osate.contract/src/org/osate/contract/execution/PythonHelper.java
+++ b/org.osate.contract/src/org/osate/contract/execution/PythonHelper.java
@@ -69,10 +69,8 @@ public class PythonHelper {
 		var env = new RuleEnvironment(new RuleEnvironmentEntry("self", context));
 		var sb = new StringBuilder();
 
-		if (true) {// ioid == null) {
-			var root = context.eResource().getContents().get(0);
-			ioid = new InstanceObjectIDMapper((SystemInstance) root);
-		}
+		var root = (SystemInstance) context.eResource().getContents().get(0);
+		ioid = InstanceObjectIDMapper.getMapper(root);
 
 		for (var part : is.getParts()) {
 			if (part instanceof IStringLiteral literal) {


### PR DESCRIPTION
Usage in python:
Given an object id passed to the script via a query result, the call to_java.getInstanceObject(id) returns the corresponding Java object in the instance model. This allows calling Java methods on the instance object.

resolves #13